### PR TITLE
systemctl: add varlink-based JSON output for manager properties

### DIFF
--- a/man/systemctl.xml
+++ b/man/systemctl.xml
@@ -345,9 +345,10 @@ Jan 12 10:46:45 example.com bluetoothd[8900]: gatt-time-server: Input/output err
 
             <para>When JSON output is requested for manager properties (using <option>--output=json</option>
             without specifying units), <command>systemctl</command> will use the varlink interface
-            <literal>io.systemd.Manager.Describe</literal> when available, which provides server-side JSON
-            generation for improved performance. If the varlink socket is not available, it falls back to
-            the traditional D-Bus method.</para>
+            <literal>io.systemd.Manager.Describe</literal> for local connections when available, which provides
+            server-side JSON generation for improved performance. For remote connections (using
+            <option>--host=</option> or <option>--machine=</option>) or if the varlink socket is not available,
+            it falls back to the traditional D-Bus method.</para>
           </listitem>
         </varlistentry>
 

--- a/src/systemctl/systemctl-show.c
+++ b/src/systemctl/systemctl-show.c
@@ -2544,7 +2544,7 @@ int verb_show(int argc, char *argv[], void *userdata) {
                 if (!arg_states && !arg_types) {
                         if (show_mode == SYSTEMCTL_SHOW_PROPERTIES) {
                                 /* systemctl show --all → show properties of the manager */
-                                if (OUTPUT_MODE_IS_JSON(arg_output))
+                                if (OUTPUT_MODE_IS_JSON(arg_output) && arg_transport == BUS_TRANSPORT_LOCAL)
                                         return show_manager_varlink_json();
                                 else
                                         return show_one(bus, "/org/freedesktop/systemd1", NULL, show_mode, &new_line, &ellipsized);


### PR DESCRIPTION
## Summary
- Implement server-side JSON generation for `systemctl show` manager properties using varlink
- Add fallback to D-Bus when varlink socket is not available  
- Update man page documentation for the new functionality

## Changes
- **systemctl-show.c**: Add `show_manager_varlink_json()` function that uses `io.systemd.Manager.Describe` varlink method
- **systemctl.xml**: Document varlink-based JSON output behavior for manager properties

## Benefits
- Improved performance by avoiding client-side bus property to JSON conversion
- Server-side JSON generation as suggested in #31948
- Maintains backward compatibility with graceful fallback

## Test plan
- [ ] Test `systemctl show --output=json` (should use varlink)
- [ ] Test fallback when varlink socket unavailable
- [ ] Verify existing functionality unchanged for non-JSON output
- [ ] Test with and without unit arguments